### PR TITLE
Add required Message Content Intent setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This MCP server is used when AI assistants need human input or judgment during t
    - Send Messages
    - Create Public Threads
    - Read Message History
+5. Enable privileged gateway intents in Bot section:
+   - Message Content Intent
 
 ### 2. Install
 


### PR DESCRIPTION
 ## Summary
 - Add setup step for enabling Message Content Intent in Discord bot configuration

## Background
The MCP server was failing to start due to the following error:

```
2025-06-25T14:42:23.575Z [human-in-the-loop] [info] Message from client: {"method":"tools/list","params":{},"jsonrpc":"2.0","id":13} { metadata: undefined }
Error: AnyError(Disallowed gateway intents were provided)
```

This occurred because the Message Content Intent (a privileged gateway intent) was not enabled in the Discord Developer Portal for the bot.
After enabling the Message Content Intent, the issue was resolved.

## Changes
- Added Step 5 to the Discord bot setup instructions to require enabling the Message Content Intent.
- This change prevents the gateway intent error and allows the MCP server to start correctly.

<img width="915" alt="image" src="https://github.com/user-attachments/assets/eaf89f77-a19d-4c87-b38a-0f4a8bc3cad0" />
