### PR TITLE
Migrate to official MCP Rust SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,8 +240,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -362,6 +364,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +448,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "encoding_rs"
@@ -691,16 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.3.1",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,7 +752,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "rust-mcp-sdk",
+ "rmcp",
+ "rmcp-macros",
+ "schemars",
  "serde",
  "serde_json",
  "serenity",
@@ -738,7 +773,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body 0.4.6",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -751,18 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
-dependencies = [
- "bytes",
- "http 1.3.1",
- "http-body 1.0.1",
- "tokio",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +793,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.32",
+ "hyper",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -885,6 +908,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1102,6 +1131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,8 +1265,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -1276,63 +1311,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-mcp-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375eba9388d9d5ffc8951e5f25296f9739be4e5700375ac7c74ad957a903b92b"
+name = "rmcp"
+version = "0.1.5"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk?branch=main#b9d7d61ebd6e8385cbc4aa105d4e25774fc1a59c"
 dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.1.5"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk?branch=main#b9d7d61ebd6e8385cbc4aa105d4e25774fc1a59c"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
- "serde",
  "serde_json",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "rust-mcp-schema"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a794de25669a2d21c5074ec5082f74f5e88863a112339fe90264d9e480b0ee8b"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rust-mcp-sdk"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4ada895bb51475eea7f9ca937b42ec5db6f3a3a67eb83051571f5b11bc6315"
-dependencies = [
- "async-trait",
- "futures",
- "hyper 1.6.0",
- "rust-mcp-macros",
- "rust-mcp-schema",
- "rust-mcp-transport",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "rust-mcp-transport"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5a7f8e688f8b15d67f8d94cc0481cd08c9f4e848f4b9e832677dd5fdb063e"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rust-mcp-schema",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -1441,6 +1448,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1530,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1581,15 +1624,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "skeptic"
@@ -1822,9 +1856,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -1859,17 +1891,6 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5.40", features = ["derive", "env"] }
-tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread", "io-std"] }
 serenity = { version = "0.12.4", features = ["collector"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rust-mcp-sdk = { version = "0.4.5", default-features = false, features = ["server", "macros", "2025_03_26"] }
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main" }
+rmcp-macros = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main" }
+schemars = "0.8"
 async-trait = "0.1.88"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,16 +4,8 @@ mod tools;
 
 use clap::Parser;
 use discord::HumanInDiscord;
-use rust_mcp_sdk::error::{McpSdkError, SdkResult};
-use rust_mcp_sdk::schema::{
-    Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
-    LATEST_PROTOCOL_VERSION,
-};
-
-use rust_mcp_sdk::{
-    mcp_server::{server_runtime, ServerRuntime},
-    McpServer, StdioTransport, TransportOptions,
-};
+use rmcp::serve_server;
+use tokio::io::{stdin, stdout};
 use serenity::all::{ChannelId, UserId};
 
 #[derive(Debug, Parser)]
@@ -27,48 +19,27 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> SdkResult<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let Args {
         discord_token,
         discord_channel_id,
         discord_user_id,
     } = Args::parse();
 
-    let server_details = InitializeResult {
-        server_info: Implementation {
-            name: "Human in the loop".to_string(),
-            version: "0.1.0".to_string(),
-        },
-        capabilities: ServerCapabilities {
-            // indicates that server support mcp tools
-            tools: Some(ServerCapabilitiesTools { list_changed: None }),
-            ..Default::default() // Using default values for other fields
-        },
-        meta: None,
-        instructions: Some(
-            "This is a Human-in-the-Loop MCP server that enables AI assistants to request \
-             information from humans via Discord. Use the 'ask_human' tool when you need \
-             information that only a human would know, such as: personal preferences, \
-             project-specific context, local environment details, or any information that \
-             is not publicly available or documented. The human will be notified in Discord \
-             and their response will be returned to you."
-                .to_string(),
-        ),
-        protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
-    };
-
-    let transport = StdioTransport::new(TransportOptions::default())?;
-
     let human = HumanInDiscord::new(discord_user_id, discord_channel_id);
     let discord = discord::start(&discord_token, human.handler().clone());
 
-    let server: ServerRuntime =
-        server_runtime::create_server(server_details, transport, mcp_handler::Handler::new(human));
-    let mcp = server.start();
+    let handler = mcp_handler::Handler::new(human);
+    let transport = (stdin(), stdout());
+    let mcp = serve_server(handler, transport);
 
     tokio::select! {
-        res = mcp => res?,
-        res = discord => res.map_err(|e| McpSdkError::AnyError(e.into_boxed_dyn_error()))?,
+        res = mcp => {
+            res?;
+        },
+        res = discord => {
+            res?;
+        },
     }
     Ok(())
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,8 +1,8 @@
-use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
-use rust_mcp_sdk::{
-    macros::{mcp_tool, JsonSchema},
-    tool_box,
-};
+use rmcp::model::{CallToolResult, Tool};
+use schemars::{JsonSchema, gen::SchemaGenerator};
+use rmcp::model::CallToolRequestParam;
+use std::sync::Arc;
+use std::borrow::Cow;
 use serde::{Deserialize, Serialize};
 
 #[async_trait::async_trait]
@@ -10,27 +10,54 @@ pub trait Human: Send + Sync + 'static {
     async fn ask(&self, question: &str) -> anyhow::Result<String>;
 }
 
-#[mcp_tool(
-    name = "ask_human",
-    description = "Ask a human for information that only they would know, such as personal preferences, project-specific context, local environment details, or non-public information",
-    idempotent_hint = false,
-    destructive_hint = false,
-    open_world_hint = false,
-    read_only_hint = false
-)]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct AskHumanTool {
     /// The question to ask the human. Be specific and provide context to help the human understand what information you need.
     question: String,
 }
 impl AskHumanTool {
-    pub async fn call_tool(&self, human: &dyn Human) -> Result<CallToolResult, CallToolError> {
-        let answer = human
-            .ask(&self.question)
-            .await
-            .map_err(|e| CallToolError(e.into_boxed_dyn_error()))?;
-        Ok(CallToolResult::text_content(answer, None))
+    pub async fn call_tool(&self, human: &dyn Human) -> anyhow::Result<CallToolResult> {
+        let answer = human.ask(&self.question).await?;
+        Ok(CallToolResult::success(vec![rmcp::model::Content::text(answer)]))
     }
 }
 
-tool_box!(HumanTools, [AskHumanTool]);
+pub enum HumanTools {
+    AskHumanTool(AskHumanTool),
+}
+
+impl HumanTools {
+    pub fn tools() -> Vec<Tool> {
+        let mut generator = SchemaGenerator::default();
+        let schema = AskHumanTool::json_schema(&mut generator);
+        let schema_value = serde_json::to_value(&schema).unwrap();
+        let schema_map = match schema_value {
+            serde_json::Value::Object(map) => Arc::new(map),
+            _ => Arc::new(serde_json::Map::new()),
+        };
+
+        vec![
+            Tool {
+                name: Cow::Borrowed("ask_human"),
+                description: Some(Cow::Borrowed("Ask a human for information that only they would know, such as personal preferences, project-specific context, local environment details, or non-public information")),
+                input_schema: schema_map,
+                annotations: None,
+            }
+        ]
+    }
+}
+
+impl TryFrom<CallToolRequestParam> for HumanTools {
+    type Error = String;
+
+    fn try_from(request: CallToolRequestParam) -> Result<Self, Self::Error> {
+        match request.name.as_ref() {
+            "ask_human" => {
+                let tool: AskHumanTool = serde_json::from_value(serde_json::Value::Object(request.arguments.unwrap_or_default()))
+                    .map_err(|e| format!("Failed to parse ask_human tool: {}", e))?;
+                Ok(HumanTools::AskHumanTool(tool))
+            }
+            _ => Err(format!("Unknown tool: {}", request.name)),
+        }
+    }
+}


### PR DESCRIPTION
Update from rust-mcp-sdk to the official MCP SDK (rmcp) for 2025-06-18 compatibility:
- Replace rust-mcp-sdk with rmcp and rmcp-macros
- Add io-std feature to tokio for stdin/stdout support
- Update ServerHandler implementation to use new API patterns
- Refactor tool definitions to work with new schema system
- Simplify server initialization using serve_server function

🤖 Generated with [Claude Code](https://claude.ai/code)