### PR TITLE
Ignore messages authored by users other than specified one.

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -91,6 +91,7 @@ impl Human for HumanInDiscord {
             .await?;
         let message = thread
             .await_reply(ctx)
+            .author_id(self.user_id)
             .await
             .ok_or_else(|| anyhow::anyhow!("Failed to await message from the human in Discord"))?;
         Ok(message.content)


### PR DESCRIPTION
  This PR adds author filtering to ensure the MCP server only collects messages from the specified user in Discord threads.

  What changed?

  - Added .author_id(self.user_id) filter when awaiting replies in Discord threads

  Why?

  Previously, the bot would respond to any message in the thread, regardless of who sent it. This could cause the MCP server to:
  - Collects messages from other users or bots
  - Process unintended input
  - Create confusing conversation flows

  Impact

  This change ensures more reliable human-in-the-loop interactions by guaranteeing that only messages from the intended user are processed.