### PR TITLE
Add `notify` functionality to human interaction tools in Discord.

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -64,6 +64,31 @@ impl HumanInDiscord {
 #[async_trait::async_trait]
 impl Human for HumanInDiscord {
     async fn ask(&self, question: &str) -> anyhow::Result<String> {
+        let (ctx, thread) = self.get_ctx_and_thread(question).await?;
+        let message_text = format!("<@{}> {question}", self.user_id.get());
+        thread
+            .send_message(&ctx.http, CreateMessage::new().content(message_text))
+            .await?;
+        let message = thread
+            .await_reply(ctx)
+            .author_id(self.user_id)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Failed to await message from the human in Discord"))?;
+        Ok(message.content)
+    }
+
+    async fn notify(&self, message: &str) -> anyhow::Result<()> {
+        let (ctx, thread) = self.get_ctx_and_thread(message).await?;
+        let message_text = format!("<@{}> {message}", self.user_id.get());
+        thread
+            .send_message(&ctx.http, CreateMessage::new().content(message_text))
+            .await?;
+        Ok(())
+    }
+}
+
+impl HumanInDiscord {
+    async fn get_ctx_and_thread(&self, title: &str) -> anyhow::Result<(&Context, ChannelId)> {
         let ctx = self
             .handler
             .ctx
@@ -72,7 +97,7 @@ impl Human for HumanInDiscord {
         let thread = self
             .thread
             .get_or_try_init(|| async {
-                let thread_title = question.chars().take(100).collect::<String>();
+                let thread_title = title.chars().take(100).collect::<String>();
                 let channel = self
                     .channel_id
                     .create_thread(
@@ -85,15 +110,6 @@ impl Human for HumanInDiscord {
                 anyhow::Ok(channel.id)
             })
             .await?;
-        let message_text = format!("<@{}> {question}", self.user_id.get());
-        thread
-            .send_message(&ctx.http, CreateMessage::new().content(message_text))
-            .await?;
-        let message = thread
-            .await_reply(ctx)
-            .author_id(self.user_id)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("Failed to await message from the human in Discord"))?;
-        Ok(message.content)
+        Ok((ctx, *thread))
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 #[async_trait::async_trait]
 pub trait Human: Send + Sync + 'static {
     async fn ask(&self, question: &str) -> anyhow::Result<String>;
+    async fn notify(&self, message: &str) -> anyhow::Result<()>;
 }
 
 pub struct HumanInTheLoop<H> {
@@ -23,6 +24,14 @@ pub struct AskHumanRequest {
         description = "The question to ask the human. Be specific and provide context to help the human understand what information you need. Ask the only one question at once."
     )]
     question: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct NotifyHumanRequest {
+    #[schemars(
+        description = "The message to send to the human. Use this to provide updates, notifications, or information that doesn't require a direct response."
+    )]
+    message: String,
 }
 
 #[tool_router]
@@ -49,6 +58,20 @@ where
             .await
             .map_err(|e| rmcp::Error::internal_error(e.to_string(), None))
     }
+
+    #[tool(
+        description = "Notify a human with a message. Use this for updates or information that doesn't require a response."
+    )]
+    async fn notify_human(
+        &self,
+        Parameters(NotifyHumanRequest { message }): Parameters<NotifyHumanRequest>,
+    ) -> Result<String, rmcp::Error> {
+        self.human
+            .notify(&message)
+            .await
+            .map_err(|e| rmcp::Error::internal_error(e.to_string(), None))?;
+        Ok("Notification sent successfully".to_string())
+    }
 }
 
 #[tool_handler]
@@ -60,11 +83,12 @@ where
         ServerInfo {
             instructions: Some(
                 "This is a Human-in-the-Loop MCP server that enables AI assistants to request \
-             information from humans via Discord. Use the 'ask_human' tool when you need \
-             information that only a human would know, such as: personal preferences, \
-             project-specific context, local environment details, or any information that \
-             is not publicly available or documented. The human will be notified in Discord \
-             and their response will be returned to you."
+             information from or notify humans via Discord. \
+             Use the 'ask_human' tool when you need information that only a human would know, \
+             such as: personal preferences, project-specific context, local environment details, \
+             or any information that is not publicly available or documented. \
+             Use the 'notify_human' tool to send notifications or updates that don't require \
+             a response. The human will be notified in Discord."
                     .to_string(),
             ),
             capabilities: ServerCapabilities::builder().enable_tools().build(),


### PR DESCRIPTION
Introduces a one-way notification capability to the Human-in-the-Loop MCP server, allowing AI assistants to provide updates via Discord without requiring a response.

## Key Changes
- **New `notify_human` Tool**: Added to `src/tools.rs` for sending non-blocking messages.
- **Trait Update**: Expanded `Human` trait with a `notify` method.
- **Discord Refactor**: Extracted `get_ctx_and_thread` in `src/discord.rs` to unify thread management for both questions and notifications.
- **Improved Docs**: Updated server instructions to include notification use cases.

## Use Cases

The `notify_human` tool is ideal for:

- Progress updates during long-running operations
- Status notifications
- Informational messages
- Non-blocking alerts

## Technical Details
- Extracted shared logic for Discord context and thread initialization.
- Implemented `NotifyHumanRequest` schema with descriptive metadata.
- Maintained consistent user tagging (`<@user_id>`) for all outgoing messages.

**Status**: Tested and verified.